### PR TITLE
Leave configurable dust when swapping tokens

### DIFF
--- a/ts/config.ts
+++ b/ts/config.ts
@@ -104,4 +104,5 @@ export interface IConfig {
   tokenListStrategy: "explorer" | "chain";
   lookbackRange: number;
   confirmDrip: boolean;
+  leaveDust: BigNumber;
 }

--- a/ts/drip/dripItAll.ts
+++ b/ts/drip/dripItAll.ts
@@ -25,7 +25,7 @@ export async function dripItAll(
     tokensToSwap.map((token) => ({
       symbol: token.symbol,
       address: token.address,
-      balance: formatUnits(token.balance, token.decimals),
+      balance: formatUnits(token.adjustedBalance, token.decimals),
       buyAmount: formatUnits(token.buyAmount, WETH_DECIMALS),
       needsApproval: token.needsApproval,
     }))

--- a/ts/drip/getTokensToSwap.ts
+++ b/ts/drip/getTokensToSwap.ts
@@ -12,7 +12,7 @@ import { getAllowances } from "./getAllowances";
 
 export interface GetTokensToSwapResult {
   buyAmount: BigNumber;
-  balance: BigNumber;
+  adjustedBalance: BigNumber;
   allowance: BigNumber;
   needsApproval: boolean;
   address: string;
@@ -45,7 +45,7 @@ export async function getTokensToSwap(
   // minValue filter again with _real_ balance
   const unfilteredWithBalanceAndAllowance = unfiltered.map((token, idx) => ({
     ...token,
-    balance: balances[idx],
+    adjustedBalance: balances[idx].sub(config.leaveDust),
     allowance: allowances[idx],
     needsApproval: allowances[idx].lt(balances[idx]),
   }));
@@ -56,7 +56,7 @@ export async function getTokensToSwap(
     unfilteredWithBalanceAndAllowance.map((token) =>
       orderBookApi.getQuote({
         sellToken: token.address,
-        sellAmountBeforeFee: token.balance.toString(),
+        sellAmountBeforeFee: token.adjustedBalance.toString(),
         kind: OrderQuoteSideKindSell.SELL,
         buyToken: config.wrappedNativeToken,
         from: config.gpv2Settlement,

--- a/ts/drip/postOrders.ts
+++ b/ts/drip/postOrders.ts
@@ -22,7 +22,7 @@ export async function postOrders(
       orderBookApi.sendOrder({
         sellToken: token.address,
         buyToken: config.wrappedNativeToken,
-        sellAmount: token.balance.toString(),
+        sellAmount: token.adjustedBalance.toString(),
         buyAmount: token.buyAmount.toString(),
         validTo: nextValidTo,
         appData: appDataContent,

--- a/ts/drip/swapTokens.ts
+++ b/ts/drip/swapTokens.ts
@@ -50,7 +50,7 @@ export const swapTokens = async (
 
   const toDrip = toActuallySwap.map((token) => ({
     token: token.address,
-    sellAmount: token.balance,
+    sellAmount: token.adjustedBalance,
     buyAmount: token.buyAmount,
   }));
 

--- a/ts/utils/readConfig.ts
+++ b/ts/utils/readConfig.ts
@@ -72,6 +72,14 @@ export async function readConfig(): Promise<
         "-c, --confirm-drip",
         "Ask for confirmation before dripping"
       ).default(false)
+    )
+    .addOption(
+      new Option(
+        "--leave-dust <wei>",
+        "Amount of each token (in wei) to leave in the contract after swapping"
+      )
+        .default(BigNumber.from(10))
+        .argParser((x) => BigNumber.from(x))
     );
 
   program.parse();
@@ -88,6 +96,7 @@ export async function readConfig(): Promise<
     lookbackRange,
     tokenListStrategy,
     confirmDrip,
+    leaveDust,
   } = options;
   const network = selectedNetwork || "mainnet";
 
@@ -147,6 +156,7 @@ export async function readConfig(): Promise<
       lookbackRange,
       targetSafe,
       confirmDrip,
+      leaveDust,
     },
     provider,
   ];


### PR DESCRIPTION
# Description

Leave a small amount of wei of every token instead of selling the full balance.

By leaving a very small buffer of tokens in the contract and not swapping them out, solvers which have made an off-by-one error in their calculations of the output amount (seems to be surprisingly common occurence) will not see their simulations revert. Additionally, leaving small buffers of tokens saves gas (15000 gas units after every drip, to be exact) by not re-initializing the storage slot repetedly after every drip.

## Changes

- Subtracts a configurable dust amount from each token's on-chain balance before quoting and posting swap orders, ensuring the settlement contract is never fully drained
- Adds `--leave-dust <wei>` CLI option (default: 10 wei) wired through `IConfig`
- - Renames `balance` to `adjustedBalance` in `GetTokensToSwapResult` to make it clear the value has been modified

## Out of scope

Leaving dust for the WETH/ETH withdrawal path requires a contract change and will be handled in a follow-up PR.

## Test plan

- [ ] Run keeper with no `--leave-dust` flag and verify orders use `balance - 10` as sell amount
- [ ] Run keeper with `--leave-dust 100` and verify orders use `balance - 100`
- [ ] Confirm the settlement contract retains the expected dust amount after orders fill
- [ ] Confirm leaving large numbers of small token amounts in the settlement contract does not negatively impact performance of `getTokensToSwap()` excessively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)