### PR TITLE
Exclude orders that sell the native token

### DIFF
--- a/ts/drip/getTokensToSwap.ts
+++ b/ts/drip/getTokensToSwap.ts
@@ -31,7 +31,7 @@ export async function getTokensToSwap(
     config
   );
 
-  // populate the balances and allowances
+  // populate the balances and allowances - exclude native token
   const tokenAddresses = unfiltered
     .filter(
       (token) => token.address.toLowerCase() !== config.wrappedNativeToken.toLowerCase()

--- a/ts/drip/getTokensToSwap.ts
+++ b/ts/drip/getTokensToSwap.ts
@@ -32,7 +32,12 @@ export async function getTokensToSwap(
   );
 
   // populate the balances and allowances
-  const tokenAddresses = unfiltered.map((token) => token.address);
+  const tokenAddresses = unfiltered
+    .filter(
+      (token) => token.address.toLowerCase() !== config.wrappedNativeToken.toLowerCase()
+    )
+    .map((token) => token.address);
+
   const [balances, allowances] = await Promise.all([
     getBalances(provider, config.gpv2Settlement, tokenAddresses),
     getAllowances(


### PR DESCRIPTION
It has been observed that, since the backend activated the placement of orders selling and buying the same token (i.e., transfers), the script has been posting orders selling and buying the wrapped native token, while at the same time withdrawing separately the native token.

This results in situations where a partially fillable open order transferring wrapped native token is placed, which then causes tiny executions, whenever a small balance of the wrapped native token shows up in the settlement contract.

This PR filters out such orders from being placed in the first place.